### PR TITLE
Unsupported Java detected (60.0).

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-TAG=multiarch-latest
+TAG=latest
 BEDROCK_PORT=19132
 JAVA_PORT=25565
 TIMEZONE=Europe/London


### PR DESCRIPTION
https://github.com/itzg/docker-minecraft-server/issues/1200#issuecomment-993088307

Unsupported Java detected (60.0). This version of Minecraft requires at least Java 17. Check your Java version with the command 'java -version'.